### PR TITLE
Mavenization - cont. 2

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -63,6 +63,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.maven-play-plugin.com.github.yeungda.jcoffeescript</groupId>
+            <artifactId>jcoffeescript-dep</artifactId>
+            <version>1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>rhino</groupId>
+                    <artifactId>js</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.maven-play-plugin.com.yahoo.platform.yui</groupId>
             <artifactId>yuicompressor</artifactId>
             <version>2.4.7</version>


### PR DESCRIPTION
JCoffeeScript

I've deployed "jcoffeescript" and "jcoffeescript-dep" version 1.1 artifacts to my repository.
"jcoffeescript" is the original one with Rhino bundled. "jcoffeescript-dep" is the original one, but with Rhino classes removed (by me). The names are just jike in JUnit case, there are two JUnit artifacts: "junit" with dependencies bundled, and "junit-dep" without them.

In "greenscript-core" I added "jcoffeescript-dep" with Rhino dependency excluded (because it's bundled in yuicompressor).
