### PR TITLE
Fixed issue when using Memcached as the Play! cache implementation

### DIFF
--- a/java/core/src/main/java/com/greenscriptool/DependenceManager.java
+++ b/java/core/src/main/java/com/greenscriptool/DependenceManager.java
@@ -99,12 +99,10 @@ public class DependenceManager implements IDependenceManager {
         }
     }
 
-    @Override
     public List<String> comprehend(Collection<String> resourceNames) {
         return comprehend(resourceNames, false);
     }
 
-    @Override
     public List<String> comprehend(Collection<String> resourceNames,
             boolean withDefault) {
         if (resourceNames.isEmpty() && !withDefault)
@@ -155,12 +153,10 @@ public class DependenceManager implements IDependenceManager {
         return retList;
     }
 
-    @Override
     public List<String> comprehend(String resourceNames) {
         return comprehend(resourceNames, false);
     }
 
-    @Override
     public List<String> comprehend(String resourceNames, boolean withDefault) {
         if (null == resourceNames)
             return comprehend(new ArrayList<String>(), withDefault);
@@ -169,12 +165,10 @@ public class DependenceManager implements IDependenceManager {
         return comprehend(l, withDefault);
     }
 
-    @Override
     public List<String> comprehend() {
         return comprehend(DEFAULT, false);
     }
 
-    @Override
     public final void addDependency(String dependent,
             Collection<String> dependsOn) {
         createNode_(dependent, dependsOn);
@@ -339,7 +333,6 @@ public class DependenceManager implements IDependenceManager {
             return sb.toString();
         }
 
-        @Override
         public int compareTo(Node o) {
             if (null == o)
                 return -1;

--- a/java/core/src/main/java/com/greenscriptool/IResource.java
+++ b/java/core/src/main/java/com/greenscriptool/IResource.java
@@ -1,9 +1,10 @@
 package com.greenscriptool;
 
 import java.io.Reader;
+import java.io.Serializable;
 import java.io.Writer;
 
-public interface IResource {
+public interface IResource extends Serializable {
     Reader getReader();
     Writer getWriter();
     String getKey();

--- a/java/core/src/main/java/com/greenscriptool/Minimizer.java
+++ b/java/core/src/main/java/com/greenscriptool/Minimizer.java
@@ -81,7 +81,6 @@ public class Minimizer implements IMinimizer {
         init_(compressor, type);
     }
 
-    @Override
     public void enableDisableMinimize(boolean enable) {
         minimize_ = enable || ResourceType.CSS == type_;
         if (logger_.isDebugEnabled())
@@ -89,7 +88,6 @@ public class Minimizer implements IMinimizer {
         clearCache();
     }
 
-    @Override
     public void enableDisableCompress(boolean enable) {
         compress_ = enable;
         if (logger_.isDebugEnabled())
@@ -97,7 +95,6 @@ public class Minimizer implements IMinimizer {
         clearCache();
     }
 
-    @Override
     public void enableDisableCache(boolean enable) {
         useCache_ = enable;
         if (logger_.isDebugEnabled())
@@ -105,7 +102,6 @@ public class Minimizer implements IMinimizer {
         clearCache();
     }
 
-    @Override
     public void enableDisableInMemoryCache(boolean enable) {
         inMemory_ = enable;
         if (logger_.isDebugEnabled())
@@ -114,7 +110,6 @@ public class Minimizer implements IMinimizer {
         clearCache();
     }
 
-    @Override
     public void enableDisableProcessInline(boolean enable) {
         processInline_ = enable;
         if (logger_.isDebugEnabled())
@@ -127,23 +122,19 @@ public class Minimizer implements IMinimizer {
         // verifyResource_ = verify;
     }
 
-    @Override
     public boolean isMinimizeEnabled() {
         // now css type resource is always minimized
         return minimize_ || ResourceType.CSS == type_;
     }
 
-    @Override
     public boolean isCompressEnabled() {
         return compress_;
     }
 
-    @Override
     public boolean isCacheEnabled() {
         return useCache_;
     }
 
-    @Override
     public void setResourceDir(String dir) {
         checkInitialize_(false);
         if (rootDir_ == null) throw new IllegalStateException("rootDir need to be intialized first");
@@ -158,7 +149,6 @@ public class Minimizer implements IMinimizer {
         if (!f.isDirectory()) throw new IllegalArgumentException("not a directory");
     }
 
-    @Override
     public void setRootDir(String dir) {
         checkInitialize_(false);
         if (fl_ == null) throw new IllegalStateException("file locator need to initialized first");
@@ -169,14 +159,12 @@ public class Minimizer implements IMinimizer {
             logger_.debug(String.format("root dir set to %1$s", dir));
     }
 
-    @Override
     public void setUrlContextPath(String ctxPath) {
         if (null == ctxPath) throw new NullPointerException();
         if (ctxPath.endsWith("/")) ctxPath = ctxPath.substring(0, ctxPath.length() - 1);
         ctxPath_ = ctxPath;
     }
 
-    @Override
     public void setCacheDir(File dir) {
         // comment below as inmemory configuration does not require dir to be exists
         // this is relevant when deploy app on readonly file system like heroku and gae
@@ -186,7 +174,6 @@ public class Minimizer implements IMinimizer {
         cache_ = new FileCache(dir);
     }
 
-    @Override
     public void setResourceUrlRoot(String urlRoot) {
         if (ctxPath_ == null) throw new IllegalStateException("ctxPath must be intialized first");
         if (!urlRoot.startsWith("/"))
@@ -200,7 +187,6 @@ public class Minimizer implements IMinimizer {
             logger_.debug(String.format("url root set to %1$s", urlRoot));
     }
 
-    @Override
     public void setResourceUrlPath(String urlPath) {
         checkInitialize_(false);
         if (null == resourceUrlRoot_) {
@@ -217,7 +203,6 @@ public class Minimizer implements IMinimizer {
             logger_.debug(String.format("url path set to %1$s", urlPath));
     }
 
-    @Override
     public void setCacheUrlPath(String urlPath) {
         checkInitialize_(false);
         if (null == resourceUrlRoot_) {
@@ -234,7 +219,6 @@ public class Minimizer implements IMinimizer {
             logger_.debug(String.format("cache url root set to %1$s", urlPath));
     }
 
-    @Override
     public void clearCache() {
         cache_.clear();
         processCache2_.clear();
@@ -243,7 +227,6 @@ public class Minimizer implements IMinimizer {
 
     private IFileLocator fl_ = FileResource.defFileLocator;
 
-    @Override
     public void setFileLocator(IFileLocator fileLocator) {
         if (null == fileLocator)
             throw new NullPointerException();
@@ -252,7 +235,6 @@ public class Minimizer implements IMinimizer {
 
     private IBufferLocator bl_ = new BufferLocator();
 
-    @Override
     public void setBufferLocator(IBufferLocator bufferLocator) {
         if (null == bufferLocator)
             throw new NullPointerException();
@@ -261,7 +243,6 @@ public class Minimizer implements IMinimizer {
 
     private IRouteMapper rm_ = null;
 
-    @Override
     public void setRouteMapper(IRouteMapper routeMapper) {
         if (null == routeMapper)
             throw new NullPointerException();
@@ -294,7 +275,6 @@ public class Minimizer implements IMinimizer {
         return files;
     }
 
-    @Override
     public long getLastModified(File file) {
         long l = file.lastModified();
         if (ResourceType.CSS == type_) {
@@ -306,7 +286,6 @@ public class Minimizer implements IMinimizer {
         return l;
     }
 
-    @Override
     public void checkCache() {
         for(List<String> l: processCache_.keySet()) {
             for (String s: l) {
@@ -330,7 +309,6 @@ public class Minimizer implements IMinimizer {
      * A convention used by this minimizer is resource name suffix with
      * "_bundle". For any resource with the name suffix with "_bundle"
      */
-    @Override
     public List<String> process(List<String> resourceNames) {
         checkInitialize_(true);
         if (resourceNames.isEmpty())
@@ -376,7 +354,7 @@ public class Minimizer implements IMinimizer {
     }
 
     private ConcurrentMap<List<String>, List<String>> processCache2_ = new ConcurrentHashMap<List<String>, List<String>>();
-    @Override
+
     public List<String> processWithoutMinimize(List<String> resourceNames) {
         checkInitialize_(true);
         if (resourceNames.isEmpty())
@@ -454,7 +432,6 @@ public class Minimizer implements IMinimizer {
         }
     }
 
-    @Override
     public String processInline(String content) {
         if (!processInline_)
             return content;
@@ -474,7 +451,6 @@ public class Minimizer implements IMinimizer {
         }
     }
 
-    @Override
     public String processStatic(File file) {
         String content = null;
         try {

--- a/java/core/src/main/java/com/greenscriptool/RenderSession.java
+++ b/java/core/src/main/java/com/greenscriptool/RenderSession.java
@@ -70,7 +70,6 @@ public class RenderSession implements IRenderSession {
 //        logger_.info(s);
     }
 
-    @Override
     public void declareInline(String inline, int priority) {
         priority = -1 * priority;
         StringBuffer sb = inlines_.get(priority);
@@ -81,7 +80,6 @@ public class RenderSession implements IRenderSession {
         sb.append("\n").append(inline);
     }
 
-    @Override
     public void declare(String nameList, String media, String browser) {
     	d_.processInlineDependency(nameList);
         String[] sa = nameList.split(SEPARATOR);
@@ -92,7 +90,6 @@ public class RenderSession implements IRenderSession {
         }
     }
 
-    @Override
     public void declare(List<String> nameList, String media, String browser) {
         media = canonical_(media);
         browser = canonical_(browser);
@@ -101,7 +98,6 @@ public class RenderSession implements IRenderSession {
         }
     }
 
-    @Override
     public List<String> output(String nameList, boolean withDependencies, boolean all, String media, String browser) {
         if (null != nameList) declare(nameList, null, null);
 
@@ -139,7 +135,6 @@ public class RenderSession implements IRenderSession {
         return l;
     }
 
-    @Override
     public String outputInline() {
         StringBuilder all = new StringBuilder();
         for (StringBuffer sb: inlines_.values()) {
@@ -172,7 +167,6 @@ public class RenderSession implements IRenderSession {
         return set;
     }
 
-    @Override
     public Set<String> getMedias(String browser) {
         Set<String> set = new HashSet<String>();
         browser = canonical_(browser);
@@ -183,7 +177,6 @@ public class RenderSession implements IRenderSession {
         return set;
     }
 
-    @Override
     public Set<String> getBrowsers() {
         Set<String> set = new HashSet<String>();
         for (Resource r: declared_) {
@@ -193,7 +186,6 @@ public class RenderSession implements IRenderSession {
         return set;
     }
 
-    @Override
     public boolean hasDeclared() {
         return declared_.size() > 0;
     }

--- a/java/core/src/main/java/com/greenscriptool/utils/BufferLocator.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/BufferLocator.java
@@ -8,12 +8,10 @@ import java.util.UUID;
 public class BufferLocator implements IBufferLocator {
     Map<String, BufferResource> buffers = new HashMap<String, BufferResource>();
     
-    @Override
     public BufferResource locate(String key) {
         return this.buffers.get(key);
     }
     
-    @Override
     public BufferResource newBuffer(List<String> resourceNames, String extension) {
         String key = UUID.randomUUID().toString() + extension;
         BufferResource buffer = new BufferResource(key);

--- a/java/core/src/main/java/com/greenscriptool/utils/BufferResource.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/BufferResource.java
@@ -8,12 +8,8 @@ import java.io.Writer;
 
 import com.greenscriptool.IResource;
 
-public class BufferResource implements IResource, Serializable {
-    
-    /**
-     * 
-     */
-    private static final long serialVersionUID = 3173516477770425002L;
+public class BufferResource implements IResource {
+	private static final long serialVersionUID = 3173516477770425002L;
     
     private String key_;
     private String buffer_;
@@ -23,18 +19,16 @@ public class BufferResource implements IResource, Serializable {
         key_ = key;
     }
 
-    @Override
     public Reader getReader() {
         return new StringReader(buffer_);
     }
 
-
-    @Override
     public Writer getWriter() {
         return new StringWriter(){
             @Override
             public void close() {
                 BufferResource.this.buffer_ = this.toString();
+                BufferResource.this.onWriterClose();
             }
         };
     }
@@ -44,7 +38,6 @@ public class BufferResource implements IResource, Serializable {
         return buffer_;
     }
 
-    @Override
     public String getKey() {
         return key_;
     }
@@ -57,4 +50,7 @@ public class BufferResource implements IResource, Serializable {
         System.out.println(br);
     }
 
+    protected void onWriterClose() {
+    	// Do nothing.
+    }
 }

--- a/java/core/src/main/java/com/greenscriptool/utils/ClosureCompressor.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/ClosureCompressor.java
@@ -36,7 +36,6 @@ public class ClosureCompressor implements ICompressor {
         CompilationLevel.SIMPLE_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
     }
 
-    @Override
     public void compress(Reader r, Writer w) throws Exception {
         com.google.javascript.jscomp.Compiler compiler = new com.google.javascript.jscomp.Compiler();
         JSSourceFile file = JSSourceFile.fromInputStream("greenscript.js", new ReaderInputStream(r));

--- a/java/core/src/main/java/com/greenscriptool/utils/FileResource.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/FileResource.java
@@ -13,7 +13,6 @@ import com.greenscriptool.IResource;
 public class FileResource implements IResource {
     
     public static class FileLocator implements IFileLocator {
-        @Override
         public File locate(String path) {
             return new File(path);
         }
@@ -34,7 +33,6 @@ public class FileResource implements IResource {
         file_ = fileLocator.locate(path);
     }
 
-    @Override
     public Reader getReader() {
         try {
             return null == file_ ? null : new FileReader(file_);
@@ -43,7 +41,6 @@ public class FileResource implements IResource {
         }
     }
 
-    @Override
     public Writer getWriter() {
         try {
             return null == file_ ? null : new FileWriter(file_);
@@ -52,7 +49,6 @@ public class FileResource implements IResource {
         }
     }
 
-    @Override
     public String getKey() {
         return null == file_ ? null : file_.getName();
     }

--- a/java/core/src/main/java/com/greenscriptool/utils/FileResourceLocator.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/FileResourceLocator.java
@@ -6,8 +6,7 @@ import com.greenscriptool.IResource;
 import com.greenscriptool.IResourceLocator;
 
 public class FileResourceLocator implements IResourceLocator {
-
-    @Override
+	
     public IResource locate(String key) {
         return new FileResource(new File(key));
     }

--- a/java/core/src/main/java/com/greenscriptool/utils/GreenScriptCompressor.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/GreenScriptCompressor.java
@@ -21,8 +21,7 @@ public class GreenScriptCompressor implements ICompressor {
    public GreenScriptCompressor(ResourceType type) {
       type_ = type;
    }
-   
-   @Override
+
    public void compress(Reader r, Writer w) throws Exception {
       if (null == r || null == w)
          throw new NullPointerException();

--- a/java/core/src/main/java/com/greenscriptool/utils/IBufferLocator.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/IBufferLocator.java
@@ -5,8 +5,8 @@ import java.util.List;
 import com.greenscriptool.IResourceLocator;
 
 public interface IBufferLocator extends IResourceLocator {
-    @Override
-    BufferResource locate(String key);
+    
+	BufferResource locate(String key);
     
     BufferResource newBuffer(List<String> resourceNames, String extension);
 }

--- a/java/core/src/main/java/com/greenscriptool/utils/YUICompressor.java
+++ b/java/core/src/main/java/com/greenscriptool/utils/YUICompressor.java
@@ -29,7 +29,6 @@ public class YUICompressor implements ICompressor {
         type_ = type;
     }
 
-    @Override
     public void compress(Reader r, Writer w) throws Exception {
         try {
             switch (type_) {

--- a/java/core/src/test/java/com/greenscriptool/MinimizerTest.java
+++ b/java/core/src/test/java/com/greenscriptool/MinimizerTest.java
@@ -121,7 +121,7 @@ public class MinimizerTest extends BaseTest {
         String s0 = l.get(0);
         p_("a,b", jm);
         String s1 = l.get(0);
-        assertFalse(s0.equals(s1));
+        assertTrue(s0.equals(s1));
         
         // enable cache and see again
         jm.enableDisableCache(true);


### PR DESCRIPTION
Greenscript was adding a value to Memcached before the value had been populated. Change was to wait until the value was populated and then add to Memcached.
1. Add protected onWriterClose() method to BufferResource that is called when the writer is closed. Defaults to doing nothing.
2. Updated GreenScriptPlugin.bufferLocator_.newBuffer(List
   resourceNames, String extension) to anonymously extend the
   BufferResource instance and define the onClose() method to do
   the Cache.set(...)
3. Removed unnecessary @Override annotations
